### PR TITLE
stages interfaces and makes Dora the default abstract format

### DIFF
--- a/packages/neon-api/src/provider/apiBalancer.ts
+++ b/packages/neon-api/src/provider/apiBalancer.ts
@@ -1,5 +1,5 @@
 import { logging, u, wallet } from "@cityofzion/neon-core";
-import { AddressAbstract, PastTransaction, Provider } from "./common";
+import { PastTransaction, Provider } from "./common";
 const log = logging.default("api");
 
 export default class ApiBalancer implements Provider {
@@ -11,9 +11,11 @@ export default class ApiBalancer implements Provider {
   }
 
   private _preference = 0;
+
   public get preference(): number {
     return this._preference;
   }
+
   public set preference(val: number) {
     const newVal = Math.max(0, Math.min(1, val));
     if (newVal !== this._preference) {
@@ -23,9 +25,11 @@ export default class ApiBalancer implements Provider {
   }
 
   private _frozen = false;
+
   public get frozen(): boolean {
     return this._frozen;
   }
+
   public set frozen(val: boolean) {
     if (this._frozen !== val) {
       val

--- a/packages/neon-api/src/provider/common.ts
+++ b/packages/neon-api/src/provider/common.ts
@@ -61,21 +61,3 @@ export function findGoodNodesFromHeight(
   const threshold = bestHeight - tolerance;
   return sortedNodes.filter((n) => n.height >= threshold);
 }
-
-export interface Entry {
-  txid: string;
-  time: number;
-  block_height: number;
-  asset: string;
-  amount: string;
-  address_to: string;
-  address_from: string;
-}
-
-export interface AddressAbstract {
-  total_pages: number;
-  total_entries: number;
-  page_size: number;
-  page_number: number;
-  entries: Entry[];
-}

--- a/packages/neon-api/src/provider/dora/class.ts
+++ b/packages/neon-api/src/provider/dora/class.ts
@@ -1,5 +1,5 @@
 import { logging, settings, u, wallet } from "@cityofzion/neon-core";
-import { AddressAbstract, PastTransaction, Provider } from "../common";
+import { PastTransaction, Provider } from "../common";
 import {
   getBalance,
   getClaims,
@@ -8,6 +8,7 @@ import {
   getRPCEndpoint,
   getAddressAbstracts,
 } from "./core";
+import { AddressAbstracts } from "./interface";
 
 const log = logging.default("api");
 
@@ -15,7 +16,7 @@ interface DoraProvider extends Provider {
   getAddressAbstracts: (
     address: string,
     page: number
-  ) => Promise<AddressAbstract>;
+  ) => Promise<AddressAbstracts>;
 }
 
 export class Dora implements DoraProvider {
@@ -41,24 +42,29 @@ export class Dora implements DoraProvider {
   public getBalance(address: string): Promise<wallet.Balance> {
     return getBalance(this.url, address);
   }
+
   public getClaims(address: string): Promise<wallet.Claims> {
     return getClaims(this.url, address);
   }
+
   public getMaxClaimAmount(address: string): Promise<u.Fixed8> {
     return getMaxClaimAmount(this.url, address);
   }
+
   public getHeight(): Promise<number> {
     return getHeight(this.url);
   }
+
   public async getTransactionHistory(
     _address: string
   ): Promise<PastTransaction[]> {
     throw new Error("Method not implemented.");
   }
+
   public getAddressAbstracts(
     address: string,
     page: number
-  ): Promise<AddressAbstract> {
+  ): Promise<AddressAbstracts> {
     return getAddressAbstracts(this.url, address, page);
   }
 }

--- a/packages/neon-api/src/provider/dora/interface.ts
+++ b/packages/neon-api/src/provider/dora/interface.ts
@@ -1,0 +1,17 @@
+export interface AddressAbstracts {
+  totalPages: number;
+  totalEntries: number;
+  pageSize: number;
+  pageNumber: number;
+  entries: Entry[];
+}
+
+export interface Entry {
+  txid: string;
+  time: number;
+  blockHeight: number;
+  asset: string;
+  amount: number;
+  addressTo: string;
+  addressFrom: string;
+}

--- a/packages/neon-api/src/provider/dora/responses.ts
+++ b/packages/neon-api/src/provider/dora/responses.ts
@@ -1,5 +1,6 @@
 import { NeoCliBalance, NeoCliClaimable } from "../neoCli/responses";
-import { AddressAbstract, Entry } from "../common";
+import { AddressAbstracts } from "./interface";
+
 export interface DoraGetBalanceResponse {
   balance: NeoCliBalance[];
   address: string;
@@ -17,9 +18,4 @@ export interface DoraGetClaimableResponse {
   unclaimed: number;
 }
 
-export type TEntry = Omit<Entry, "amount"> & { amount: number };
-
-export interface DoraAddressAbstracts
-  extends Omit<AddressAbstract, "entries"> {
-  entries: TEntry[];
-}
+export type DoraGetAddressAbstractsResponse = AddressAbstracts;

--- a/packages/neon-api/src/provider/neoCli/class.ts
+++ b/packages/neon-api/src/provider/neoCli/class.ts
@@ -1,5 +1,5 @@
 import { logging, rpc, u, wallet } from "@cityofzion/neon-core";
-import { AddressAbstract, PastTransaction, Provider } from "../common";
+import { PastTransaction, Provider } from "../common";
 import { getBalance, getClaims, getMaxClaimAmount } from "./core";
 
 const log = logging.default("api");
@@ -8,6 +8,7 @@ export class NeoCli implements Provider {
   public get name(): string {
     return `NeoCli[${this.url}]`;
   }
+
   private url: string;
 
   private rpc: rpc.RPCClient;
@@ -17,21 +18,27 @@ export class NeoCli implements Provider {
     this.rpc = new rpc.RPCClient(url);
     log.info(`Created NeoCli Provider: ${this.url}`);
   }
+
   public getRPCEndpoint(_noCache?: boolean | undefined): Promise<string> {
     return Promise.resolve(this.url);
   }
+
   public getBalance(address: string): Promise<wallet.Balance> {
     return getBalance(this.url, address);
   }
+
   public getClaims(address: string): Promise<wallet.Claims> {
     return getClaims(this.url, address);
   }
+
   public getMaxClaimAmount(address: string): Promise<u.Fixed8> {
     return getMaxClaimAmount(this.url, address);
   }
+
   public getHeight(): Promise<number> {
     return this.rpc.getBlockCount();
   }
+
   public getTransactionHistory(_address: string): Promise<PastTransaction[]> {
     throw new Error("Method not implemented.");
   }

--- a/packages/neon-api/src/provider/neoCli/responses.ts
+++ b/packages/neon-api/src/provider/neoCli/responses.ts
@@ -14,6 +14,7 @@ export interface NeoCliBalance {
   asset_symbol: string;
   amount: number;
 }
+
 export interface NeoCliTx {
   txid: string;
   value: number;

--- a/packages/neon-api/src/provider/neonDB/class.ts
+++ b/packages/neon-api/src/provider/neonDB/class.ts
@@ -1,5 +1,5 @@
 import { logging, rpc, settings, u, wallet } from "@cityofzion/neon-core";
-import { AddressAbstract, PastTransaction, Provider } from "../common";
+import { PastTransaction, Provider } from "../common";
 import {
   getBalance,
   getClaims,
@@ -18,6 +18,7 @@ export class NeonDB implements Provider {
   }
 
   private rpc: rpc.RPCClient | null = null;
+
   private cacheExpiry: Date | null = null;
 
   public constructor(url: string) {
@@ -50,15 +51,19 @@ export class NeonDB implements Provider {
   public getBalance(address: string): Promise<wallet.Balance> {
     return getBalance(this.url, address);
   }
+
   public getClaims(address: string): Promise<wallet.Claims> {
     return getClaims(this.url, address);
   }
+
   public getMaxClaimAmount(address: string): Promise<u.Fixed8> {
     return getMaxClaimAmount(this.url, address);
   }
+
   public getHeight(): Promise<number> {
     return getHeight(this.url);
   }
+
   public getTransactionHistory(address: string): Promise<PastTransaction[]> {
     return getTransactionHistory(this.url, address);
   }

--- a/packages/neon-api/src/provider/neoscan/class.ts
+++ b/packages/neon-api/src/provider/neoscan/class.ts
@@ -1,5 +1,6 @@
 import { logging, rpc, settings, u, wallet } from "@cityofzion/neon-core";
-import { AddressAbstract, PastTransaction, Provider } from "../common";
+import { PastTransaction, Provider } from "../common";
+import { AddressAbstracts } from "../dora/interface";
 import {
   getBalance,
   getClaims,
@@ -15,7 +16,7 @@ interface NeoscanProvider extends Provider {
   getAddressAbstracts: (
     address: string,
     page: number
-  ) => Promise<AddressAbstract>;
+  ) => Promise<AddressAbstracts>;
 }
 
 export class Neoscan implements NeoscanProvider {
@@ -53,22 +54,27 @@ export class Neoscan implements NeoscanProvider {
   public getBalance(address: string): Promise<wallet.Balance> {
     return getBalance(this.url, address);
   }
+
   public getClaims(address: string): Promise<wallet.Claims> {
     return getClaims(this.url, address);
   }
+
   public getMaxClaimAmount(address: string): Promise<u.Fixed8> {
     return getMaxClaimAmount(this.url, address);
   }
+
   public getHeight(): Promise<number> {
     return getHeight(this.url);
   }
+
   public getTransactionHistory(address: string): Promise<PastTransaction[]> {
     return getTransactionHistory(this.url, address);
   }
+
   public getAddressAbstracts(
     address: string,
     page: number
-  ): Promise<AddressAbstract> {
+  ): Promise<AddressAbstracts> {
     return getAddressAbstracts(this.url, address, page);
   }
 }

--- a/packages/neon-api/src/provider/neoscan/interface.ts
+++ b/packages/neon-api/src/provider/neoscan/interface.ts
@@ -1,0 +1,82 @@
+import { AddressAbstracts, Entry } from "../dora/interface";
+
+// An AddressAbstracts interface with a string "amount" field in entries
+export interface AddressAbstractsString
+  extends Omit<AddressAbstracts, "entries"> {
+  entries: EntryString[];
+}
+
+// An Entry interface with a string "amount" field
+export type EntryString = Omit<Entry, "amount"> & { amount: string };
+
+
+export interface NeoscanBalance {
+  asset: string;
+  amount: number;
+  unspent: NeoscanTx[];
+}
+
+export interface NeoscanClaim {
+  txid: string;
+  n: number;
+  value: number;
+  unclaimed: number;
+  start_height: number;
+  end_height: number;
+}
+
+export interface NeoscanPastTx {
+  vouts: [
+    {
+      value: number;
+      transaction_id: number;
+      asset: string;
+      address_hash: string;
+    }
+  ];
+  vin: [
+    {
+      value: number;
+      txid: string;
+      n: number;
+      asset: string;
+      address_hash: string;
+    }
+  ];
+  type: string;
+  txid: string;
+  transfers: [
+    {
+      txid: string;
+      time: number;
+      contract: string;
+      block_height: number;
+      amount: number;
+      address_to: string;
+      address_from: string;
+    }
+  ];
+  time: number;
+  sys_fee: string;
+  size: number;
+  net_fee: string;
+  id: number;
+  claims: [
+    {
+      value: number;
+      txid: string;
+      n: number;
+      asset: string;
+      address_hash: string;
+    }
+  ];
+  block_height: number;
+  block_hash: string;
+  asset: null;
+}
+
+export interface NeoscanTx {
+  txid: string;
+  value: number;
+  n: number;
+}

--- a/packages/neon-api/src/provider/neoscan/responses.ts
+++ b/packages/neon-api/src/provider/neoscan/responses.ts
@@ -1,34 +1,18 @@
-import { AddressAbstract } from "../common";
+import {
+  AddressAbstractsString,
+  NeoscanBalance,
+  NeoscanClaim
+} from "./interface";
+
 export interface NeoscanV1GetBalanceResponse {
   balance: NeoscanBalance[] | null;
   address: string;
-}
-
-export interface NeoscanBalance {
-  asset: string;
-  amount: number;
-  unspent: NeoscanTx[];
-}
-
-export interface NeoscanTx {
-  txid: string;
-  value: number;
-  n: number;
 }
 
 export interface NeoscanV1GetClaimableResponse {
   unclaimed: number;
   claimable: NeoscanClaim[] | null;
   address: string;
-}
-
-export interface NeoscanClaim {
-  txid: string;
-  n: number;
-  value: number;
-  unclaimed: number;
-  start_height: number;
-  end_height: number;
 }
 
 export interface NeoscanV1GetUnclaimedResponse {
@@ -40,54 +24,4 @@ export interface NeoscanV1GetHeightResponse {
   height: number;
 }
 
-export interface NeoscanPastTx {
-  vouts: [
-    {
-      value: number;
-      transaction_id: number;
-      asset: string;
-      address_hash: string;
-    }
-  ];
-  vin: [
-    {
-      value: number;
-      txid: string;
-      n: number;
-      asset: string;
-      address_hash: string;
-    }
-  ];
-  type: string;
-  txid: string;
-  transfers: [
-    {
-      txid: string;
-      time: number;
-      contract: string;
-      block_height: number;
-      amount: number;
-      address_to: string;
-      address_from: string;
-    }
-  ];
-  time: number;
-  sys_fee: string;
-  size: number;
-  net_fee: string;
-  id: number;
-  claims: [
-    {
-      value: number;
-      txid: string;
-      n: number;
-      asset: string;
-      address_hash: string;
-    }
-  ];
-  block_height: number;
-  block_hash: string;
-  asset: null;
-}
-
-export type NeoscanAddressAbstracts = AddressAbstract;
+export type NeoscanGetAddressAbstractsResponse = AddressAbstractsString;


### PR DESCRIPTION
This PR implements a number of changes to the handling of the neon-api package.  In order of importance:
* Aligns `AddressAbstract` with the correct API syntax `AddressAbstracts`
* Updates the `AddressAbstracts` interface to set Dora as the default response format with Neoscan using a modified version to ensure cleaner code after Neoscan EoL
* Migrates interfaces which are not a response to their own files (we need to refactor the entire package to align with the state of the ecosystem...in another PR)
* Updates Interface names for clarity
* Aligns code architecture with regards to the response handling and interfaces
* Updates spacing for consistancy
## Do Not Merge ; Pending Checkout